### PR TITLE
FLOE-309: Move sticky-keys instructions to appear only once turned on

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -548,8 +548,16 @@ input[type="text"].gpii-fd-keyboard-input:focus {
                 0 0 0 0.6rem rgb(0, 0, 0);
     outline: none;
 }
+.gpii-fd-keyboard-assistance {
+    height: 14rem;
+}
 .gpii-fd-keyboard-assistanceHide {
     visibility: hidden;
+}
+.gpii-fd-keyboard-stickyKeysAdjuster-accomodationInstr {
+    display: block;
+    text-align: left;
+    padding: 0 2rem 1rem 2rem;
 }
 .gpii-fd-keyboard-try,
 .gpii-fd-keyboard-accomodationToggle {

--- a/src/html/keyboard.html
+++ b/src/html/keyboard.html
@@ -1,8 +1,9 @@
 <p class="gpiic-fd-keyboard-instructions gpiic-fd-keyboard-stickyKeysAdjuster-desc gpiic-fd-instructions gpii-fd-instructions"></p>
 <div class="gpii-fd-controls text-center">
-    <div class="gpiic-fd-keyboard-assistance">
+    <div class="gpiic-fd-keyboard-assistance gpii-fd-keyboard-assistance">
         <button class="gpiic-fd-keyboard-stickyKeysAdjuster-try gpii-fd-keyboard-try">try it</button>
         <span class="gpiic-fd-keyboard-stickyKeysAdjuster-accomodation">
+            <span class="gpiic-fd-keyboard-stickyKeysAdjuster-accomodationInstr gpii-fd-keyboard-stickyKeysAdjuster-accomodationInstr"></span>
             <span class="gpiic-fd-keyboard-stickyKeysAdjuster-accomodationName"></span>
             <strong class="gpiic-fd-keyboard-stickyKeysAdjuster-accomodationState"></strong>
             <button class="gpiic-fd-keyboard-stickyKeysAdjuster-accomodationToggle gpii-fd-keyboard-accomodationToggle"></button>

--- a/src/js/stickyKeysAdjuster.js
+++ b/src/js/stickyKeysAdjuster.js
@@ -21,6 +21,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
             description: ".gpiic-fd-keyboard-stickyKeysAdjuster-desc",
             tryButton: ".gpiic-fd-keyboard-stickyKeysAdjuster-try",
             accomodation: ".gpiic-fd-keyboard-stickyKeysAdjuster-accomodation",
+            accomodationInstr: ".gpiic-fd-keyboard-stickyKeysAdjuster-accomodationInstr",
             accomodationName: ".gpiic-fd-keyboard-stickyKeysAdjuster-accomodationName",
             accomodationState: ".gpiic-fd-keyboard-stickyKeysAdjuster-accomodationState",
             accomodationToggle: ".gpiic-fd-keyboard-stickyKeysAdjuster-accomodationToggle"
@@ -74,6 +75,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     gpii.firstDiscovery.keyboard.stickyKeysAdjuster.renderText = function (that) {
         var resolveFn = that.msgResolver.resolve;
 
+        that.locate("accomodationInstr").html(resolveFn("stickyKeysAccomInstr"));
         that.locate("description").html(resolveFn("stickyKeysInstructions"));
         that.locate("tryButton").text(resolveFn("try"));
         that.locate("accomodationName").text(resolveFn("stickyKeys"));

--- a/src/messages/keyboard.json
+++ b/src/messages/keyboard.json
@@ -8,7 +8,8 @@
     "turnOn": "turn ON",
     "turnOff": "turn OFF",
 
-    "stickyKeysInstructions": "<strong>Sticky Keys</strong> can help with holding two keys down at once. <br/><br/>With Sticky Keys on, type @ by first pressing the Shift key and then the 2 key.",
+    "stickyKeysInstructions": "<strong>Sticky Keys</strong> can help with holding two keys down at once.",
+    "stickyKeysAccomInstr": "With Sticky Keys on, type @ by first pressing the Shift key and then the 2 key.",
     "stickyKeys": "Sticky Keys is",
 
     "successInstructions": "You don’t appear to need any keyboard adjustments. Please proceed to the next screen.",


### PR DESCRIPTION
@jobara, this branch is a small change to the sticky keys pages: Dana wanted the "press shift first, then 2" instructions to only appear _after_ sticky keys is turned on, so I separated it from the basic instructions. This is intended to be merged into your FLOE-299 branch directly.
